### PR TITLE
🚚 move to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,15 +47,15 @@ jobs:
 
     - name: Use ddev latest stable
       if: matrix.ddev_version == 'latest'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'
@@ -65,7 +65,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
+      run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
         docker pull memcached:1.6 >/dev/null
     - name: tmate debugging session

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![tests](https://github.com/drud/ddev-adminer/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-adminer/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 # DDEV Adminer Service
 
 ## What is this?
 
-This repository allows you to quickly install Adminer database manager into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get drud/ddev-adminer`.
+This repository allows you to quickly install Adminer database manager into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get ddev/ddev-adminer`.
 
 Adminer is a full-featured database management tool written in PHP. This service
 currently ships the [official adminer container](https://hub.docker.com/_/adminer)
@@ -19,7 +19,7 @@ This currently supports:
 
 ## Installation
 
-* `ddev get drud/ddev-adminer && ddev restart`
+* `ddev get ddev/ddev-adminer && ddev restart`
 
 Then you can just `ddev launcha -a` or use `ddev describe` to get the URL (`https://<project>.ddev.site:9101`).
 


### PR DESCRIPTION
This PR updates docs and tests for move to `ddev` domain.