### PR TITLE
bump github-action-add-on-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: "false"
 
+permissions:
+  actions: write
+
 jobs:
   tests:
     strategy:
@@ -24,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v0
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The Issue
Currently the addon uses an older version of ddev-action-add-on-test.

`v0` has an issue with creating fake commits to prevent Github from disabling scheduled tests.

## How This PR Solves The Issue

This PR bumps github-action-add-on to `v2`.
This prevents the dummy commits created by the keep-alive action.

@see https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

