### PR TITLE
refactor: launch `ddev adminer` by port, remove `ddev launcha`, move `ddev adminer` to project level

### DIFF
--- a/commands/host/adminer
+++ b/commands/host/adminer
@@ -5,60 +5,11 @@
 ## Usage: adminer
 ## Example: "ddev adminer"
 
-if [ "${DDEV_PROJECT_STATUS-running}" != "running" ] && [ -z "$no_recursion" ]; then
-  echo "Project ${DDEV_PROJECT} is not running, starting it"
-  ddev start
-  start_exit_code=$?
-  if [ $start_exit_code -ne 0 ]; then
-    exit $start_exit_code
-  fi
-  # run this script again, as the environment is updated after "ddev start"
-  no_recursion=true ddev "$(basename "$0")" "$@"
-  exit $?
-fi
-
 DDEV_ADMINER_PORT=9100
 DDEV_ADMINER_HTTPS_PORT=9101
 
-FULLURL=${DDEV_PRIMARY_URL}
-HTTPS=""
-if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
-
-if [[ ! -z "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then
-    FULLURL="${FULLURL/-${DDEV_HOST_WEBSERVER_PORT}/-${DDEV_ADMINER_PORT}}"
+if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then
+    ddev launch $DDEV_PRIMARY_URL:$DDEV_ADMINER_HTTPS_PORT
 else
-    if [ "${HTTPS}" = "" ]; then
-        FULLURL="${FULLURL%:[0-9]*}:${DDEV_ADMINER_PORT}"
-    else
-        FULLURL="${FULLURL%:[0-9]*}:${DDEV_ADMINER_HTTPS_PORT}"
-    fi
+    ddev launch $DDEV_PRIMARY_URL:$DDEV_ADMINER_PORT
 fi
-
-if [ -n "${1:-}" ] ; then
-  if [[ ${1::1} != "/" ]] ; then
-    FULLURL="${FULLURL}/";
-  fi
-
-  FULLURL="${FULLURL}${1}";
-fi
-
-if [ "${DDEV_DEBUG:-}" = "true" ]; then
-    printf "FULLURL $FULLURL\n" && exit 0
-fi
-
-case $OSTYPE in
-  linux-gnu)
-    if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
-        gp preview ${FULLURL}
-    else
-        xdg-open ${FULLURL}
-    fi
-    ;;
-  "darwin"*)
-    open ${FULLURL}
-    ;;
-  "win*"* | "msys"*)
-    start ${FULLURL}
-    ;;
-esac
-

--- a/commands/host/launcha
+++ b/commands/host/launcha
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-#ddev-generated
-## Description: DEPRECATED, use "ddev adminer" instead.
-printf "'ddev launcha' is no longer available. Use 'ddev launch' and 'ddev adminer' instead. See https://github.com/ddev/ddev-adminer"
-exit 2

--- a/docker-compose.adminer.yaml
+++ b/docker-compose.adminer.yaml
@@ -19,6 +19,9 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
+    volumes:
+    - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
     depends_on:
     - db
 

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ name: adminer
 project_files:
 - docker-compose.adminer.yaml
 - adminer
+- commands/host/adminer
 
 pre_install_actions:
   # Ensure we're on DDEV 1.23+. It's need for the `adminer` command (launch by port).
@@ -11,7 +12,3 @@ pre_install_actions:
     #ddev-nodisplay
     #ddev-description:Checking DDEV version
     (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to use this add-on." && false)
-
-global_files:
-- commands/host/adminer
-- commands/host/launcha

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,13 @@ project_files:
 - docker-compose.adminer.yaml
 - adminer
 
+pre_install_actions:
+  # Ensure we're on DDEV 1.23+. It's need for the `adminer` command (launch by port).
+  - |
+    #ddev-nodisplay
+    #ddev-description:Checking DDEV version
+    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to use this add-on." && false)
+
 global_files:
 - commands/host/adminer
 - commands/host/launcha

--- a/install.yaml
+++ b/install.yaml
@@ -7,7 +7,7 @@ project_files:
 - commands/host/adminer
 
 pre_install_actions:
-  # Ensure we're on DDEV 1.23+. It's need for the `adminer` command (launch by port).
+  # Ensure we're on DDEV 1.23+. It's required for the `adminer` command (launch by port).
   - |
     #ddev-nodisplay
     #ddev-description:Checking DDEV version

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -25,15 +25,6 @@ teardown() {
   (ddev restart >/dev/null || (echo "# ddev restart returned exit code=%?" >&3 && false))
   ddev help adminer | grep adminer >/dev/null
 
-  # ddev launcha must return an error
-  (exit_status=0; (ddev launcha > /dev/null 2>&1) || exit_status=$?; echo $exit_status) | {
-      read exit_status
-      if [ $exit_status -eq 0 ]; then
-          echo "Test failed: ddev launcha exited with no error"
-          exit 2
-      fi
-  }
-
 #  echo "# Trying curl -s -L -k https://${PROJNAME}.ddev.site:9101/" >&3
   curl --fail -s -L -k https://${PROJNAME}.ddev.site:9101/ | grep 'document.querySelector.*auth.*db' >/dev/null
 }


### PR DESCRIPTION
## The Issue

Launch can be simpler with DDEV v1.23.0+

## How This PR Solves The Issue

Refactors the code. Adds volumes from:

- https://github.com/ddev/ddev-addon-template/pull/45

Moves `ddev adminer` command from `~/.ddev/commands/host/adminer` to `$DDEV_APPROOT/.ddev/commands/host/adminer`

And removes `ddev launcha` completely (almost a year this command is not intended to be used).

```
ddev get https://github.com/ddev/ddev-adminer/tarball/20240611_stasadev_launch
ddev restart
ddev adminer
```