### PR TITLE
Make add-on work w/o ddev-router, update tests, fixes #25

### DIFF
--- a/commands/host/adminer
+++ b/commands/host/adminer
@@ -8,8 +8,8 @@
 DDEV_ADMINER_PORT=9100
 DDEV_ADMINER_HTTPS_PORT=9101
 
-if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then
-    ddev launch $DDEV_PRIMARY_URL:$DDEV_ADMINER_HTTPS_PORT
+if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
+    ddev launch :$DDEV_ADMINER_PORT
 else
-    ddev launch $DDEV_PRIMARY_URL:$DDEV_ADMINER_PORT
+    ddev launch :$DDEV_ADMINER_HTTPS_PORT
 fi

--- a/docker-compose.adminer_norouter.yaml
+++ b/docker-compose.adminer_norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 8080 to 9100
+services: {}

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,7 @@ name: adminer
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
 - docker-compose.adminer.yaml
+- docker-compose.adminer_norouter.yaml
 - adminer
 - commands/host/adminer
 
@@ -12,3 +13,13 @@ pre_install_actions:
     #ddev-nodisplay
     #ddev-description:Checking DDEV version
     (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to use this add-on." && false)
+
+post_install_actions:
+  - |
+    #ddev-description:If router disabled, directly expose port
+    #
+    if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
+      printf "#ddev-generated\nservices:\n  adminer:\n    ports:\n      - 9100:8080\n" > docker-compose.adminer_norouter.yaml
+    fi
+  - |
+    echo "You can now use 'ddev adminer' to launch Adminer"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,30 +1,64 @@
 setup() {
-  mkcert -install >/dev/null
+  set -eu -o pipefail
+  brew_prefix=$(brew --prefix)
+  load "${brew_prefix}/lib/bats-support/load.bash"
+  load "${brew_prefix}/lib/bats-assert/load.bash"
+
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=$(mktemp -d -t testadminer-XXXXXXXXXX)
-  export PROJNAME=testadminer
+  export TESTDIR=~/tmp/test-adminer
+  mkdir -p $TESTDIR
+  export PROJNAME=test-adminer
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} >/dev/null || true
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
-  echo ${PROJNAME}
-  ddev start -y >/dev/null
+  ddev start -y >/dev/null 2>&1
+}
+
+health_checks() {
+  set +u # bats-assert has unset variables so turn off unset check
+  # ddev restart is required because we have done `ddev get` on a new service
+  run ddev restart
+  assert_success
+  # Make sure we can hit the 9101 port successfully
+  curl -s -I -f https://${PROJNAME}.ddev.site:9101 >/tmp/curlout.txt
+  # Make sure `ddev adminer` works
+  DDEV_DEBUG=true run ddev adminer
+  assert_success
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:9101"
 }
 
 teardown() {
-  cd ${TESTDIR}
-  ddev delete -Oy ${PROJNAME} || true
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
-@test "basic installation" {
-  set -o pipefail
-  cd ${TESTDIR} || ( printf "# unable to cd to ${TESTDIR}\n" >&3 && false )
+@test "install from directory" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
-  (ddev restart >/dev/null || (echo "# ddev restart returned exit code=%?" >&3 && false))
-  ddev help adminer | grep adminer >/dev/null
+  ddev get ${DIR} >/dev/null 2>&1
+  ddev mutagen sync >/dev/null 2>&1
+  health_checks
+}
 
-#  echo "# Trying curl -s -L -k https://${PROJNAME}.ddev.site:9101/" >&3
-  curl --fail -s -L -k https://${PROJNAME}.ddev.site:9101/ | grep 'document.querySelector.*auth.*db' >/dev/null
+@test "install from release" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev get ddev/ddev-adminer with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-adminer >/dev/null 2>&1
+  ddev restart >/dev/null 2>&1
+  health_checks
+}
+
+@test "install from directory with nonstandard port" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  ddev config --router-http-port=8080 --router-https-port=8443
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR} >/dev/null 2>&1
+  ddev mutagen sync >/dev/null 2>&1
+  health_checks
 }


### PR DESCRIPTION
## The Issue

- #25

## How This PR Solves The Issue

In terms of functionality, this add-on is similar to https://github.com/ddev/ddev-phpmyadmin
This PR contains recent fixes and improvements from `ddev-phpmyadmin`.

## Manual Testing Instructions

Test it locally and in Gitpod.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ddev/ddev)

```
ddev get https://github.com/ddev/ddev-adminer/tarball/20240718_stasadev_norouter
ddev restart
ddev adminer
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

