### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ This currently supports:
 
 ## Installation
 
-* `ddev get ddev/ddev-adminer && ddev restart`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ddev/ddev-adminer
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get ddev/ddev-adminer
+```
+
+Afterwards run `ddev restart`
 
 Then you can just `ddev adminer` or use `ddev describe` to get the URL (`https://<project>.ddev.site:9101`).
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.