### PR TITLE
Use `ddev add-on` command

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -17,7 +17,7 @@ setup() {
 
 health_checks() {
   set +u # bats-assert has unset variables so turn off unset check
-  # ddev restart is required because we have done `ddev get` on a new service
+  # ddev restart is required because we have done `ddev add-on get` on a new service
   run ddev restart
   assert_success
   # Make sure we can hit the 9101 port successfully
@@ -38,8 +38,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null 2>&1
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} >/dev/null 2>&1
   ddev mutagen sync >/dev/null 2>&1
   health_checks
 }
@@ -47,8 +47,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-adminer with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-adminer >/dev/null 2>&1
+  echo "# ddev add-on get ddev/ddev-adminer with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ddev/ddev-adminer >/dev/null 2>&1
   ddev restart >/dev/null 2>&1
   health_checks
 }
@@ -57,8 +57,8 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   ddev config --router-http-port=8080 --router-https-port=8443
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null 2>&1
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} >/dev/null 2>&1
   ddev mutagen sync >/dev/null 2>&1
   health_checks
 }


### PR DESCRIPTION
## The Issue
`ddev get` was deprecated in `v1.23.5`.

## How This PR Solves The Issue
This PR updates the tests to use the `ddev add-on` command.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

