### PR TITLE
feat: use official Adminer, fixes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,35 @@ ddev add-on get ddev/ddev-adminer && ddev restart
 
 Then you can just `ddev adminer` or use `ddev describe` to get the URL (`https://<project>.ddev.site:9101`).
 
-To customize Adminer setup:
+## Advanced Customization
+
+To change the design:
 
 ```sh
-# drivers: server, sqlite, sqlite2, pgsql, oracle, mssql, mongo, and more via plugins
-# plugins: https://www.adminer.org/en/plugins/
 # design: https://www.adminer.org/en/#extras
-ddev dotenv set .ddev/.env.adminer \
-    --adminer-docker-image="adminer:standalone" \
-    --adminer-default-driver=server \
-    --adminer-default-db=db \
-    --adminer-default-username=db \
-    --adminer-default-password=db \
-    --adminer-plugins="tables-filter edit-calendar" \
-    --adminer-design=dracula
+ddev dotenv set .ddev/.env.adminer --adminer-design=dracula
 git add .ddev/.env.adminer
 ddev add-on get ddev/ddev-adminer && ddev restart
 ```
+
+To add more plugins:
+
+```sh
+# plugins: https://www.adminer.org/en/plugins/
+ddev dotenv set .ddev/.env.adminer --adminer-plugins="tables-filter edit-calendar"
+git add .ddev/.env.adminer
+ddev add-on get ddev/ddev-adminer && ddev restart
+```
+
+All possible customization options are listed below (avoid using them if you're unsure):
+
+- `--adminer-design`
+- `--adminer-docker-image`
+- `--adminer-default-driver`
+- `--adminer-default-db`
+- `--adminer-default-username`
+- `--adminer-default-password`
+- `--adminer-plugins`
 
 ## What does this add-on do?
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@
 
 ## What is this?
 
-This repository allows you to quickly install the [AdminerEvo](https://docs.adminerevo.org/) fork of the [adminer](https://www.adminer.org/) database manager into a [DDEV](https://ddev.readthedocs.io) project using just `ddev add-on get ddev/ddev-adminer`.
+This repository allows you to quickly install the [Adminer](https://www.adminer.org/) database manager into a [DDEV](https://ddev.readthedocs.io) project using just `ddev add-on get ddev/ddev-adminer`.
 
-Adminer is a full-featured database management tool written in PHP. This service
-currently ships the [official adminer container](https://hub.docker.com/_/adminer)
-with no _external_ plugins. It contains all official plugins and themes and allows
-to easily chose one by editing the `docker-compose.adminer.yaml` file after
-installation.
+Adminer is a full-featured database management tool written in PHP. This service currently ships the [official adminer container](https://hub.docker.com/_/adminer) with no _external_ plugins.
 
-AdminerEvo works with MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, Elasticsearch and MongoDB.
+Adminer works with MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, and MongoDB.
 
 ## Installation
 
@@ -21,6 +17,24 @@ ddev add-on get ddev/ddev-adminer && ddev restart
 ```
 
 Then you can just `ddev adminer` or use `ddev describe` to get the URL (`https://<project>.ddev.site:9101`).
+
+To customize Adminer setup:
+
+```sh
+# drivers: server, sqlite, sqlite2, pgsql, oracle, mssql, mongo, and more via plugins
+# plugins: https://www.adminer.org/en/plugins/
+# design: https://www.adminer.org/en/#extras
+ddev dotenv set .ddev/.env.adminer \
+    --adminer-docker-image="adminer:standalone" \
+    --adminer-default-driver=server \
+    --adminer-default-db=db \
+    --adminer-default-username=db \
+    --adminer-default-password=db \
+    --adminer-plugins="tables-filter edit-calendar" \
+    --adminer-design=dracula
+git add .ddev/.env.adminer
+ddev add-on get ddev/ddev-adminer && ddev restart
+```
 
 ## What does this add-on do?
 

--- a/docker-compose.adminer.yaml
+++ b/docker-compose.adminer.yaml
@@ -2,31 +2,47 @@
 services:
   adminer:
     container_name: ddev-${DDEV_SITENAME}-adminer
-    image: shyim/adminerevo:latest
+    image: ${ADMINER_DOCKER_IMAGE:-adminer:standalone}
     environment:
-      # Use the line below to change the adminer theme.
-      # - ADMINER_DESIGN=nette
-      - ADMINER_DEFAULT_SERVER=db
-      - ADMINER_DEFAULT_USER=db
-      - ADMINER_DEFAULT_PASSWORD=db
-      - ADMINER_DEFAULT_DB=db
-      - ADMINER_PLUGINS=tables-filter
+      - ADMINER_DEFAULT_DRIVER=${ADMINER_DEFAULT_DRIVER:-${DDEV_DATABASE_FAMILY:-server}}
+      - ADMINER_DEFAULT_SERVER=${ADMINER_DEFAULT_SERVER:-db}
+      - ADMINER_DEFAULT_DB=${ADMINER_DEFAULT_DB:-db}
+      - ADMINER_DEFAULT_USERNAME=${ADMINER_DEFAULT_USERNAME:-db}
+      - ADMINER_DEFAULT_PASSWORD=${ADMINER_DEFAULT_PASSWORD:-db}
+      - ADMINER_PLUGINS=${ADMINER_PLUGINS:-tables-filter}
+      - ADMINER_DESIGN=${ADMINER_DESIGN:-}
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=9100:8080
       - HTTPS_EXPOSE=9101:8080
-      - DDEV_DBIMAGE
-      - DDEV_DB_NAME=db
-      - DDEV_DB_USER=db
-      - DDEV_DB_PASS=db
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     volumes:
-    - ".:/mnt/ddev_config"
-    - "ddev-global-cache:/mnt/ddev-global-cache"
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
     depends_on:
-    - db
+      - db
+    configs:
+      - source: adminer-index.php
+        target: /var/www/html/index.php
 
-  web:
-    links:
-      - adminer:adminer
+configs:
+  adminer-index.php:
+    content: |
+      <?php
+        if (!count($$_GET)) {
+          if ($$_ENV['ADMINER_DEFAULT_DRIVER'] === 'mysql') {
+            $$_ENV['ADMINER_DEFAULT_DRIVER'] = 'server';
+          } else if ($$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgres') {
+            $$_ENV['ADMINER_DEFAULT_DRIVER'] = 'pgsql';
+          }
+          $$_POST['auth'] = [
+            'driver' => $$_ENV['ADMINER_DEFAULT_DRIVER'],
+            'server' => $$_ENV['ADMINER_DEFAULT_SERVER'],
+            'db' => $$_ENV['ADMINER_DEFAULT_DB'],
+            'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
+            'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
+          ];
+        }
+        include './adminer.php';
+      ?>

--- a/install.yaml
+++ b/install.yaml
@@ -9,11 +9,6 @@ project_files:
 ddev_version_constraint: '>= v1.24.2'
 
 pre_install_actions:
-  # Ensure we're on DDEV 1.23+. It's required for the `adminer` command (launch by port).
-  - |
-    #ddev-nodisplay
-    #ddev-description:Checking DDEV version
-    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to use this add-on." && false)
   - |
     #ddev-nodisplay
     #ddev-description:Removing old adminer files


### PR DESCRIPTION
## The Issue

- #31

## How This PR Solves The Issue

- Uses `adminer:standalone`
- Adds `.ddev/.env.adminer`
- Uses docker-compose configs https://docs.docker.com/reference/compose-file/configs/ (I didn't know about them.)
  Found an example here:
  - https://github.com/TimWolla/docker-adminer/issues/13#issuecomment-2023730622

## Manual Testing Instructions

```
# design: https://www.adminer.org/en/#extras
ddev dotenv set .ddev/.env.adminer --adminer-design=dracula
ddev add-on get https://github.com/ddev/ddev-adminer/tarball/20250227_stasadev_adminer_official
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
