### PR TITLE
fix: set file permission on index.php

### DIFF
--- a/docker-compose.adminer.yaml
+++ b/docker-compose.adminer.yaml
@@ -25,6 +25,7 @@ services:
     configs:
       - source: adminer-index.php
         target: /var/www/html/index.php
+        mode: "0444"
 
 configs:
   adminer-index.php:


### PR DESCRIPTION
## The Issue

Tests are failing on DDEV HEAD

```
$ ddev logs -s adminer
...
GET / - Failed opening required '/var/www/html/index.php' (include_path='.:/usr/local/lib/php') in Unknown on line 0
...
```

docker-compose v2.34.0 changed default permission from 0444 to 0440

- https://github.com/docker/compose/commit/b6f313b8a5b771545f4af9d0f07ae43dbcade2ef
- https://github.com/compose-spec/compose-go/pull/738

## How This PR Solves The Issue

Sets `mode: "0444"`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
