### PR TITLE
Use last commit badge instead of maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![tests](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml?query=branch%3Amain)
-[![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)](https://github.com/ddev/ddev-adminer/commits)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-adminer)](https://github.com/ddev/ddev-adminer/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-adminer)](https://github.com/ddev/ddev-adminer/releases/latest)
 
 # DDEV Adminer


### PR DESCRIPTION
## The Issue

Maintained badge required manual update from time to time.

## How This PR Solves The Issue

Uses https://shields.io/badges/git-hub-last-commit-branch instead.

## Manual Testing Instructions

https://github.com/ddev/ddev-adminer/blob/20250410_stasadev_last_commit/README.md

![image](https://github.com/user-attachments/assets/166cd573-d97d-4a5b-b5cd-96d65b3095b8)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
