### PR TITLE
feat: add add-on registry badge, set time for tests from upstream

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
   schedule:
-  - cron: '01 07 * * *'
+  - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-adminer/actions/workflows/tests.yml?query=branch%3Amain)
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-adminer)](https://github.com/ddev/ddev-adminer/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-adminer)](https://github.com/ddev/ddev-adminer/releases/latest)
@@ -14,7 +15,7 @@ Adminer works with MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, and Mongo
 
 ## Installation
 
-```sh
+```bash
 ddev add-on get ddev/ddev-adminer
 ddev restart
 ```
@@ -27,12 +28,13 @@ After installation, make sure to commit the `.ddev` directory to version control
 | ------- | ----------- |
 | `ddev adminer` | Open Adminer in your browser (`https://<project>.ddev.site:9101`) |
 | `ddev describe` | View service status and used ports for Adminer |
+| `ddev logs -s adminer` | Check Adminer logs |
 
 ## Advanced Customization
 
 To change the design:
 
-```sh
+```bash
 # design: https://www.adminer.org/en/#extras
 ddev dotenv set .ddev/.env.adminer --adminer-design=dracula
 ddev add-on get ddev/ddev-adminer
@@ -43,7 +45,7 @@ Make sure to commit the `.ddev/.env.adminer` file to version control.
 
 To add more plugins:
 
-```sh
+```bash
 # plugins: https://www.adminer.org/en/plugins/
 ddev dotenv set .ddev/.env.adminer --adminer-plugins="tables-filter edit-calendar"
 ddev add-on get ddev/ddev-adminer


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-tempate` has some changes.

## How This PR Solves The Issue

- Adds add-on registry badge
- Adds command for logs `ddev logs -s adminer`
- Set time for tests from upstream

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
