### PR TITLE
fix: correctly load Adminer plugins, fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ ddev add-on get ddev/ddev-adminer
 ddev restart
 ```
 
+If a plugin *requires* parameters, refer to the [official documentation](https://hub.docker.com/_/adminer) for more details.
+
 Make sure to commit the `.ddev/.env.adminer` file to version control.
 
 All customization options (use with caution):

--- a/docker-compose.adminer.yaml
+++ b/docker-compose.adminer.yaml
@@ -22,13 +22,14 @@ services:
       - "ddev-global-cache:/mnt/ddev-global-cache"
     depends_on:
       - db
+    command: ["php", "-S", "[::]:8080", "-t", "/var/www/html", "ddev-adminer.php"]
     configs:
-      - source: adminer-index.php
-        target: /var/www/html/index.php
+      - source: ddev-adminer.php
+        target: /var/www/html/ddev-adminer.php
         mode: "0444"
 
 configs:
-  adminer-index.php:
+  ddev-adminer.php:
     content: |
       <?php
         if (!count($$_GET)) {
@@ -45,5 +46,5 @@ configs:
             'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
           ];
         }
-        include './adminer.php';
+        include './index.php';
       ?>


### PR DESCRIPTION
## The Issue

- #41

We override the original `index.php`, which loads plugins.

Before (`tables-filter` is not loaded, unable to filter by table):

![image](https://github.com/user-attachments/assets/a1e97e1c-6797-4ca8-94cd-06525bbc63bd)

## How This PR Solves The Issue

Uses `ddev-adminer.php` instead of `index.php` for PHP web server entrypoint, which allows to use the original `index.php` without modifications.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-adminer/tarball/20250501_stasadev_plugins
ddev restart
ddev adminer
```

After (`tables-filter` is loaded, input is available):

![image](https://github.com/user-attachments/assets/5fb108bd-84b8-4060-9e37-a82082d142bc)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
