### PR TITLE
fix: remove check for db container, for #51

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -23,12 +23,6 @@ pre_install_actions:
     if [ "${has_old_files}" = true ]; then
       exit 2
     fi
-  - |
-    #ddev-description:Check for db service
-    if ddev utility configyaml 2>/dev/null | grep omit_containers | grep -q db; then
-      echo "Unable to install the add-on because no db service was found"
-      exit 3
-    fi
 
 ddev_version_constraint: '>= v1.24.10'
 


### PR DESCRIPTION
## The Issue

For:

- #51

## How This PR Solves The Issue

We don't need to check for the `db` container, because people can use Adminer with SQLite.

## Manual Testing Instructions

```bash
ddev config --omit-containers=db
ddev add-on get https://github.com/ddev/ddev-adminer/tarball/refs/pull/52/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
